### PR TITLE
feat: optional serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,11 @@ repository = "https://github.com/JesperAxelsson/rust-intmap"
 keywords = ["hashmap", "u64", "intmap"]
 
 [dependencies]
+serde = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]
 rand = "0.3"
 ordermap = "0.2.7"
+
+[package.metadata.docs.rs]
+features = ["serde"]

--- a/integration_tests/serde/Cargo.toml
+++ b/integration_tests/serde/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "intmap-integration-test-serde"
+version = "0.1.0"
+edition = "2018"
+license = "MIT"
+
+[dev-dependencies]
+intmap = { path = "../..", features = ["serde"] }
+proptest = "1.0.0"
+serde_json = "1"

--- a/integration_tests/serde/tests/roundtrip.rs
+++ b/integration_tests/serde/tests/roundtrip.rs
@@ -1,0 +1,13 @@
+use intmap::IntMap;
+use proptest::collection::hash_map;
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn test_roundtrip(m in hash_map(any::<u64>(), any::<String>(), 0..20)) {
+        let im: IntMap<_> = m.into_iter().collect();
+        let bytes = serde_json::to_vec(&im).unwrap();
+        let im_copy = serde_json::from_slice(&bytes[..]).unwrap();
+        prop_assert_eq!(im, im_copy);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 extern crate core;
 
+#[cfg(feature = "serde")]
+mod serde;
+
 use core::iter::{IntoIterator, Iterator};
 
 #[derive(Clone)]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,64 @@
+use crate::IntMap;
+use serde::{
+    de::{Deserializer, MapAccess, Visitor},
+    ser::SerializeMap,
+    Deserialize, Serialize, Serializer,
+};
+
+impl<T: Serialize> Serialize for IntMap<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.len()))?;
+        for (k, v) in self.iter() {
+            map.serialize_entry(k, v)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for IntMap<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(IntMapVisitor::new())
+    }
+}
+
+struct IntMapVisitor<V> {
+    marker: std::marker::PhantomData<fn() -> IntMap<V>>,
+}
+
+impl<V> IntMapVisitor<V> {
+    fn new() -> Self {
+        IntMapVisitor {
+            marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'de, V> Visitor<'de> for IntMapVisitor<V>
+where
+    V: Deserialize<'de>,
+{
+    type Value = IntMap<V>;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "IntMap<{}>", std::any::type_name::<V>())
+    }
+
+    fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let mut map = IntMap::with_capacity(access.size_hint().unwrap_or(0));
+
+        while let Some((key, value)) = access.next_entry()? {
+            map.insert(key, value);
+        }
+
+        Ok(map)
+    }
+}


### PR DESCRIPTION
This change adds optional support for serializing/deserializing
IntMaps using https://serde.rs framework.

The feature is disabled by default, you need to enable the `serde`
feature explicitly to get serde support:

```
intmap = { version = "0.7.2", features = ["serde"] }
```