### PR TITLE
Swap collections instead of moving contents

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,13 +351,8 @@ impl<V> IntMap<V> {
         let new_lim = self.lim();
         self.mod_mask = (new_lim as u64) - 1;
 
-        let mut vec: Vec<Vec<(u64, V)>> = Vec::new();
-
-        vec.append(&mut self.cache);
-
-        for _ in 0..new_lim {
-            self.cache.push(Vec::with_capacity(0));
-        }
+        let mut vec: Vec<Vec<(u64, V)>> = (0..new_lim).map(|_| Vec::new()).collect();
+        std::mem::swap(&mut self.cache, &mut vec);
 
         for k in vec.into_iter().flatten() {
             let ix = self.calc_index(k.0);


### PR DESCRIPTION
I was hoping this might be slightly more efficient because the internal Vecs aren't being moved and the collect knows exactly what capacity to make the new outer Vec, but the benchmark was too wibbly-wobbly to know for sure if this helps. Maybe criterion would be more accurate? At least the code is shorter.

My other idea was to drain all the entries into a single level Vec to preserve the allocations already in self.cache[ix] and minimize further allocations, but that didn't bench very well. My guess is that it is quicker to (de)allocate than copy memory around.
```rs
let vec: Vec<(u64, V)> = self.cache.iter_mut().flat_map(|v| v.drain(..)).collect();
self.cache.extend((0..new_lim - self.cache.len()).map(|_| Vec::new()));
```