### PR TITLE
clippy

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -16,7 +16,7 @@ pub enum Entry<'a, V: 'a> {
 impl<'a, V> Entry<'a, V> {
     #[inline]
     pub(crate) fn new(key: u64, int_map: &'a mut IntMap<V>) -> Self {
-        let (cache_ix, val_ix) = Self::indices(key, &int_map);
+        let (cache_ix, val_ix) = Self::indices(key, int_map);
 
         match val_ix {
             Some(vals_ix) => Entry::Occupied(OccupiedEntry {
@@ -24,10 +24,7 @@ impl<'a, V> Entry<'a, V> {
                 vals: &mut int_map.cache[cache_ix],
                 count: &mut int_map.count,
             }),
-            None => Entry::Vacant(VacantEntry {
-                key,
-                int_map: int_map,
-            }),
+            None => Entry::Vacant(VacantEntry { key, int_map }),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ impl<V> IntMap<V> {
     pub fn remove(&mut self, key: u64) -> Option<V> {
         let ix = self.calc_index(key);
 
-        let ref mut vals = self.cache[ix];
+        let vals = &mut self.cache[ix];
 
         for i in 0..vals.len() {
             let peek = vals[i].0;
@@ -203,7 +203,7 @@ impl<V> IntMap<V> {
             }
         }
 
-        return None;
+        None
     }
 
     /// Returns true if key is in map.
@@ -293,7 +293,7 @@ impl<V> IntMap<V> {
     /// map.remove(21);
     /// assert!(map.is_empty());
     /// ```
-    pub fn is_empty(&mut self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.count == 0
     }
 
@@ -330,8 +330,8 @@ impl<V> IntMap<V> {
     #[inline]
     fn hash_u64(seed: u64) -> u64 {
         let a = 11400714819323198549u64;
-        let val = a.wrapping_mul(seed);
-        val
+
+        a.wrapping_mul(seed)
     }
 
     #[inline]
@@ -357,7 +357,7 @@ impl<V> IntMap<V> {
         for k in vec.into_iter().flatten() {
             let ix = self.calc_index(k.0);
 
-            let ref mut vals = self.cache[ix];
+            let vals = &mut self.cache[ix];
             vals.push(k);
         }
 

--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -31,7 +31,7 @@ mod tests {
         let data = get_random_range(count as usize);
         let mut map: IntMap<u64> = IntMap::new();
 
-        println!("");
+        println!();
         println!("Starting test");
 
         for s in data.iter() {


### PR DESCRIPTION
[Clippy](https://github.com/rust-lang/rust-clippy) is a code linter. I was going to run it earlier, but it wanted to make a lot of changes, so I postponed it for awhile.
It's also suggesting changing `&'a Vec<Vec<(K, V)>>` to `&'a [Vec<(K, V)>]` ([clippy::ptr_arg](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg)) in the iter functions, which while it wouldn't be a problem, it doesn't really match expectations.