### PR TITLE
add ahashmap and a no-op hash variant to benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ serde = { version = "1.0", optional = true, default-features = false }
 [dev-dependencies]
 rand = "0.8.5"
 indexmap = "1.8.2"
-
+ahash = { version = "*" }
 [package.metadata.docs.rs]
 features = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ serde = { version = "1.0", optional = true, default-features = false }
 [dev-dependencies]
 rand = "0.8.5"
 indexmap = "1.8.2"
-ahash = { version = "*" }
+ahash = "0.8.11"
+hashbrown = "0.14.5"
+
 [package.metadata.docs.rs]
 features = ["serde"]

--- a/benches/basic_bench.rs
+++ b/benches/basic_bench.rs
@@ -6,10 +6,10 @@ extern crate test;
 
 extern crate indexmap;
 
+use ahash::AHashMap;
 use indexmap::IndexMap;
 use intmap::IntMap;
 use std::collections::HashMap;
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -17,6 +17,124 @@ mod tests {
     use test::Bencher;
 
     const VEC_COUNT: usize = 10_000;
+    // ********** Ahash **********
+
+    #[bench]
+    fn u64_insert_ahash(b: &mut Bencher) {
+        let data = get_random_range(VEC_COUNT);
+        let mut map = AHashMap::with_capacity(data.len());
+
+        b.iter(|| {
+            map.clear();
+
+            for s in data.iter() {
+                test::black_box(map.insert(s, s));
+            }
+        });
+    }
+
+    #[bench]
+    fn u64_insert_ahash_without_capacity(b: &mut Bencher) {
+        let data = get_random_range(VEC_COUNT);
+
+        b.iter(|| {
+            let mut map = AHashMap::new();
+
+            for s in data.iter() {
+                test::black_box(map.insert(s, s));
+            }
+
+            test::black_box(&map);
+        });
+    }
+
+    #[bench]
+    fn u64_get_ahash(b: &mut Bencher) {
+        let data = get_random_range(VEC_COUNT);
+        let mut map: AHashMap<&u64, &u64> = AHashMap::with_capacity(data.len());
+
+        for s in data.iter() {
+            test::black_box(map.insert(s, s));
+        }
+
+        b.iter(|| {
+            for s in data.iter() {
+                test::black_box({
+                    map.contains_key(s);
+                });
+            }
+        });
+    }
+
+    // ********** No Op **********
+    struct NoOpHasher(u64);
+    impl std::hash::Hasher for NoOpHasher {
+        fn finish(&self) -> u64 {
+            self.0
+        }
+
+        fn write(&mut self, _: &[u8]) {
+            unimplemented!()
+        }
+
+        fn write_u64(&mut self, i: u64) {
+            self.0 = i;
+        }
+    }
+    impl std::hash::BuildHasher for NoOpHasher {
+        type Hasher = NoOpHasher;
+
+        fn build_hasher(&self) -> Self::Hasher {
+            NoOpHasher(0)
+        }
+    }
+    #[bench]
+    fn u64_insert_no_op(b: &mut Bencher) {
+        let data = get_random_range(VEC_COUNT);
+        let mut map = HashMap::with_capacity_and_hasher(data.len(), NoOpHasher(0));
+
+        b.iter(|| {
+            map.clear();
+
+            for s in data.iter() {
+                test::black_box(map.insert(s, s));
+            }
+        });
+    }
+
+    #[bench]
+    fn u64_insert_no_op_without_capacity(b: &mut Bencher) {
+        let data = get_random_range(VEC_COUNT);
+
+        b.iter(|| {
+            let mut map = HashMap::with_hasher(NoOpHasher(0));
+
+            for s in data.iter() {
+                test::black_box(map.insert(s, s));
+            }
+
+            test::black_box(&map);
+        });
+    }
+
+    #[bench]
+    fn u64_get_no_op(b: &mut Bencher) {
+        let data = get_random_range(VEC_COUNT);
+        let mut map: HashMap<&u64, &u64, NoOpHasher> =
+            HashMap::with_capacity_and_hasher(data.len(), NoOpHasher(0));
+
+        for s in data.iter() {
+            test::black_box(map.insert(s, s));
+        }
+
+        b.iter(|| {
+            for s in data.iter() {
+                test::black_box({
+                    map.contains_key(s);
+                });
+            }
+        });
+    }
 
     // ********** Built in **********
 

--- a/benches/basic_bench.rs
+++ b/benches/basic_bench.rs
@@ -7,6 +7,7 @@ extern crate test;
 extern crate indexmap;
 
 use ahash::AHashMap;
+use hashbrown::HashMap as BrownMap;
 use indexmap::IndexMap;
 use intmap::IntMap;
 use std::collections::HashMap;
@@ -17,6 +18,56 @@ mod tests {
     use test::Bencher;
 
     const VEC_COUNT: usize = 10_000;
+
+    // ********** HashBrown **********
+
+    #[bench]
+    fn u64_insert_brown(b: &mut Bencher) {
+        let data = get_random_range(VEC_COUNT);
+        let mut map = BrownMap::with_capacity(data.len());
+
+        b.iter(|| {
+            map.clear();
+
+            for s in data.iter() {
+                test::black_box(map.insert(s, s));
+            }
+        });
+    }
+
+    #[bench]
+    fn u64_insert_brown_without_capacity(b: &mut Bencher) {
+        let data = get_random_range(VEC_COUNT);
+
+        b.iter(|| {
+            let mut map = BrownMap::new();
+
+            for s in data.iter() {
+                test::black_box(map.insert(s, s));
+            }
+
+            test::black_box(&map);
+        });
+    }
+
+    #[bench]
+    fn u64_get_brown(b: &mut Bencher) {
+        let data = get_random_range(VEC_COUNT);
+        let mut map: BrownMap<&u64, &u64> = BrownMap::with_capacity(data.len());
+
+        for s in data.iter() {
+            test::black_box(map.insert(s, s));
+        }
+
+        b.iter(|| {
+            for s in data.iter() {
+                test::black_box({
+                    map.contains_key(s);
+                });
+            }
+        });
+    }
+
     // ********** Ahash **********
 
     #[bench]


### PR DESCRIPTION
I wanted to add `ahash` and `no-op` hashes to check how they perform relatively. 
I know `no-op` is not exactly a hash, but there are common cases where the keys are already random. The best example is probably `std::any::TypeId` which is used in [bevy](https://github.com/bevyengine/bevy/blob/main/crates/bevy_utils/src/lib.rs#L360) and many other libraries like [egui](https://github.com/emilk/egui/blob/master/crates/egui/src/util/id_type_map.rs#L351) or [flecs-rs](https://github.com/jazzay/flecs-rs/blob/main/src/cache.rs#L39C2-L39C22).

I also added `HashBrownMap` as it seems to be popular and serves as an alternative to std. It uses `ahash` by default at this moment.


The README shows 
|name | time |
| -------- | ------- |
|get_built_in    |22,320 ns/iter (+/- 446)|
|get_intmap |2,959 ns/iter (+/- 148)|
|insert_built_in |27,666 ns/iter (+/- 1,230)|
|insert_intmap| 14,047 ns/iter (+/- 1,461)|


But when I ran the benchmarks on my PC with `cargo +nightly bench` I got the following results 
|name | time |
| -------- | ------- |
|get_ahash                        |      31,663.90 ns/iter (+/- 30.20)      |
|get_brown                        |      35,274.26 ns/iter (+/- 35.20)      |
|get_built_in                     |     135,327.27 ns/iter (+/- 977.37)     |
|get_indexmap                     |     158,904.48 ns/iter (+/- 696.72)     |
|get_intmap                       |      41,835.94 ns/iter (+/- 64.88)      |
|get_no_op                        |      20,464.68 ns/iter (+/- 31.09)      |
|insert_ahash                     |      78,251.27 ns/iter (+/- 896.50)     |
|insert_ahash_without_capacity    |     246,609.52 ns/iter (+/- 833.62)     |
|insert_brown                     |      67,379.19 ns/iter (+/- 167.35)     |
|insert_brown_without_capacity    |     208,466.40 ns/iter (+/- 796.46)     |
|insert_built_in                  |     189,085.58 ns/iter (+/- 4,039.36)   |    
|insert_built_in_without_capacity |     466,260.85 ns/iter (+/- 982.45)     |
|insert_intmap                    |      74,454.27 ns/iter (+/- 2,788.48)   |    
|insert_intmap_without_capacity   |     844,878.60 ns/iter (+/- 13,812.12)  |    
|insert_no_op                     |      65,322.24 ns/iter (+/- 894.27)     |
|insert_no_op_without_capacity    |     193,376.62 ns/iter (+/- 688.68)     |

I don't know if I am doing something wrong, or maybe stdlib got better over time, but the README's measurements definitely don't reflect the current status.

It would nice if you could run the benchmarks yourself and update the README. It will help users take a more informed decision on whether intmap would be suitable for their usecase or not. 