### PR TITLE
Make IntMap::new const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `IntMap::new` is now const and creates an instance with zero capacity, thus will not allocate. The latter is also true for `IntMap::default`. Previously the initial capacity was 4. If you want to restore the old behavior, you can use `IntMap::with_capacity(4)`.
+
 ## [2.0.0] 2022-07-17
 
 ### Added Breaking!


### PR DESCRIPTION
Changes:

- `IntMap::new` is now const, thus it doesn't allocate memory.
- `IntMap::with_capacity` doesn't allocate memory if capacity is zero. Previously it allocated space for at least one element.
- Previously we assumed that there is at least space for one more element. Therefore `IntMap::insert` and `IntMap::insert_checked` didn't need to increase the cache at the beginning. This changed. I added another field `IntMap::needs_increase` to keep track if an increase is necessary. Now we handle this flag at the beginning of these functions and set it at the end.
- All getter functions need to handle an empty `IntMap` properly. I added shortcuts at the beginning of these functions.

Closed #49 