### PR TITLE
Add test with random operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "intmap-integration-test-random-ops"
+version = "0.1.0"
+dependencies = [
+ "intmap",
+ "proptest",
+]
+
+[[package]]
 name = "intmap-integration-test-serde"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,6 @@ features = ["serde"]
 [workspace]
 resolver = "2"
 members = [
+    "integration_tests/random_ops",
     "integration_tests/serde",
 ]

--- a/integration_tests/random_ops/Cargo.toml
+++ b/integration_tests/random_ops/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "intmap-integration-test-random-ops"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[dependencies]
+intmap = { path = "../.." }
+proptest = "1.0.0"

--- a/integration_tests/random_ops/src/lib.rs
+++ b/integration_tests/random_ops/src/lib.rs
@@ -1,0 +1,252 @@
+use std::collections::HashMap;
+
+use intmap::IntMap;
+use proptest::collection::vec;
+use proptest::prelude::*;
+
+#[derive(Clone, Debug)]
+pub struct Capacity(usize);
+
+impl Capacity {
+    const MAX: usize = 100;
+
+    fn arb() -> impl Strategy<Value = Self> {
+        (0usize..=Self::MAX).prop_map(Self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LoadFactor(f32);
+
+impl LoadFactor {
+    fn arb() -> impl Strategy<Value = Self> {
+        (1.0f32..=10.0f32).prop_map(Self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Key(u64);
+
+impl Key {
+    fn arb() -> impl Strategy<Value = Self> {
+        prop_oneof![
+            // Small keys with high probability for collision
+            10 => 0u64..=10u64,
+            // Totally arbitrary keys
+            1 => any::<u64>(),
+        ]
+        .prop_map(Self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Value(u8);
+
+impl Value {
+    fn arb() -> impl Strategy<Value = Self> {
+        any::<u8>().prop_map(Self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Pairs(Vec<(u64, u8)>);
+
+impl Pairs {
+    fn arb() -> impl Strategy<Value = Self> {
+        vec(
+            (Key::arb().prop_map(|k| k.0), Value::arb().prop_map(|v| v.0)),
+            0usize..Capacity::MAX,
+        )
+        .prop_map(Self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Ctor {
+    New,
+    WithCapacity(Capacity),
+    Default,
+    FromIter(Pairs),
+}
+
+impl Ctor {
+    pub fn arb() -> impl Strategy<Value = Self> {
+        prop_oneof![
+            Just(Self::New),
+            Capacity::arb().prop_map(Self::WithCapacity),
+            Just(Self::Default),
+            Pairs::arb().prop_map(Self::FromIter),
+        ]
+    }
+
+    pub fn apply(&self) -> (IntMap<u8>, HashMap<u64, u8>) {
+        match self {
+            Self::New => (IntMap::new(), HashMap::new()),
+            Self::WithCapacity(capacity) => (IntMap::with_capacity(capacity.0), HashMap::new()),
+            Self::Default => (IntMap::default(), HashMap::new()),
+            Self::FromIter(pairs) => (
+                IntMap::from_iter(pairs.0.clone()),
+                HashMap::from_iter(pairs.0.clone()),
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Op {
+    SetLoadFactor(LoadFactor),
+    GetLoadFactor,
+    Reserve(Capacity),
+    Insert((Key, Value)),
+    InsertChecked((Key, Value)),
+    Get(Key),
+    GetMut(Key),
+    Remove(Key),
+    ContainsKey(Key),
+    Clear,
+    Retain(Value),
+    IsEmpty,
+    Iter,
+    IterMut,
+    Keys,
+    Values,
+    ValuesMut,
+    Drain,
+    Len,
+    Load,
+    LoadRate,
+    Capacity,
+    Collisions,
+    Entry(Key),
+    Clone,
+    Debug,
+    Extend(Pairs),
+}
+
+impl Op {
+    pub fn arb_vec(max_size: usize) -> impl Strategy<Value = Vec<Self>> {
+        vec(Op::arb(), 0..=max_size)
+    }
+
+    pub fn arb() -> impl Strategy<Value = Self> {
+        prop_oneof![
+            1 => LoadFactor::arb().prop_map(Self::SetLoadFactor),
+            10 => Just(Self::GetLoadFactor),
+            1 => Capacity::arb().prop_map(Self::Reserve),
+            50 => (Key::arb(), Value::arb()).prop_map(Self::Insert),
+            10 => (Key::arb(), Value::arb()).prop_map(Self::InsertChecked),
+            10 => Key::arb().prop_map(Self::Get),
+            10 => Key::arb().prop_map(Self::GetMut),
+            10 => Key::arb().prop_map(Self::Remove),
+            10 => Key::arb().prop_map(Self::ContainsKey),
+            1 => Just(Self::Clear),
+            1 => Value::arb().prop_map(Self::Retain),
+            1 => Just(Self::IsEmpty),
+            1 => Just(Self::Iter),
+            1 => Just(Self::IterMut),
+            1 => Just(Self::Keys),
+            1 => Just(Self::Values),
+            1 => Just(Self::ValuesMut),
+            1 => Just(Self::Drain),
+            1 => Just(Self::Len),
+            1 => Just(Self::Load),
+            1 => Just(Self::LoadRate),
+            1 => Just(Self::Capacity),
+            1 => Just(Self::Collisions),
+            10 => Key::arb().prop_map(Self::Entry),
+            1 => Just(Self::Clone),
+            1 => Just(Self::Debug),
+            1 => Pairs::arb().prop_map(Self::Extend),
+        ]
+    }
+
+    pub fn apply(&self, map: &mut IntMap<u8>, reference: &mut HashMap<u64, u8>) {
+        match self {
+            Self::SetLoadFactor(load_factor) => {
+                map.set_load_factor(load_factor.0);
+            }
+            Self::GetLoadFactor => {
+                map.get_load_factor();
+            }
+            Self::Reserve(additional) => {
+                map.reserve(additional.0);
+            }
+            Self::Insert((key, value)) => {
+                assert_eq!(map.insert(key.0, value.0), reference.insert(key.0, value.0));
+            }
+            Self::InsertChecked((key, value)) => {
+                map.insert_checked(key.0, value.0);
+                reference.entry(key.0).or_insert(value.0);
+            }
+            Self::Get(key) => {
+                assert_eq!(map.get(key.0), reference.get(&key.0));
+            }
+            Self::GetMut(key) => {
+                assert_eq!(map.get_mut(key.0), reference.get_mut(&key.0));
+            }
+            Self::Remove(key) => {
+                assert_eq!(map.remove(key.0), reference.remove(&key.0));
+            }
+            Self::ContainsKey(key) => {
+                assert_eq!(map.contains_key(key.0), reference.contains_key(&key.0));
+            }
+            Self::Clear => {
+                map.clear();
+                reference.clear();
+            }
+            Self::Retain(value) => {
+                map.retain(|_, &v| v != value.0);
+                reference.retain(|_, &mut v| v != value.0);
+            }
+            Self::IsEmpty => {
+                assert_eq!(map.is_empty(), reference.is_empty())
+            }
+            Self::Iter => {
+                assert_eq!(map.iter().count(), reference.len())
+            }
+            Self::IterMut => {
+                assert_eq!(map.iter_mut().count(), reference.len())
+            }
+            Self::Keys => {
+                assert_eq!(map.keys().count(), reference.len())
+            }
+            Self::Values => {
+                assert_eq!(map.values().count(), reference.len())
+            }
+            Self::ValuesMut => {
+                assert_eq!(map.values_mut().count(), reference.len())
+            }
+            Self::Drain => {
+                assert_eq!(map.drain().count(), reference.drain().count());
+            }
+            Self::Len => {
+                assert_eq!(map.len(), reference.len());
+            }
+            Self::Load => {
+                map.load();
+            }
+            Self::LoadRate => {
+                map.load_rate();
+            }
+            Self::Capacity => {
+                map.capacity();
+            }
+            Self::Collisions => {
+                map.collisions();
+            }
+            Self::Entry(key) => {
+                map.entry(key.0);
+            }
+            Self::Clone => {
+                *map = map.clone();
+            }
+            Self::Debug => {
+                format!("{map:?}");
+            }
+            Self::Extend(pairs) => {
+                map.extend(pairs.0.clone());
+                reference.extend(pairs.0.clone());
+            }
+        }
+    }
+}

--- a/integration_tests/random_ops/tests/random_ops.rs
+++ b/integration_tests/random_ops/tests/random_ops.rs
@@ -1,0 +1,49 @@
+use std::collections::HashMap;
+
+use intmap::IntMap;
+use intmap_integration_test_random_ops::{Ctor, Op};
+use proptest::prelude::*;
+
+proptest! {
+    // This test performs random operations on IntMap to ensure that no operation
+    // fails due to violated invariants. Also all mutable operations are performed
+    // on an reference implementation (HashMap). The elements of the final IntMap
+    // are compared with the elements of the reference implementation.
+    #[test]
+    fn test_random_ops(
+        ctor in Ctor::arb(),
+        ops in Op::arb_vec(200),
+    ) {
+        let (mut map, mut reference) = ctor.apply();
+        assert_map(&map, &reference);
+
+        for op in ops {
+            op.apply(&mut map, &mut reference);
+            assert_map(&map, &reference);
+        }
+
+        let mut map_values = map.iter().collect::<Vec<_>>();
+        map_values.sort_by_key(|(&key, _)| key);
+
+        let mut reference_values = reference.iter().collect::<Vec<_>>();
+        reference_values.sort_by_key(|(&key, _)| key);
+
+        assert_eq!(map_values, reference_values);
+    }
+}
+
+fn assert_map(map: &IntMap<u8>, reference: &HashMap<u64, u8>) {
+    let debug = false;
+    if debug {
+        println!(
+            "IntMap len={} capacity={} load={} load_rate={}",
+            map.len(),
+            map.capacity(),
+            map.load(),
+            map.load_rate(),
+        );
+    }
+
+    map.assert_count();
+    assert_eq!(map.len(), reference.len());
+}


### PR DESCRIPTION
Similar to `basic_test.rs`, but performs operations in random order. Might be useful to detect if invariants are violated for more complicated cases. 