### PR TITLE
Improve documentation of load factor

### DIFF
--- a/integration_tests/random_ops/src/lib.rs
+++ b/integration_tests/random_ops/src/lib.rs
@@ -20,7 +20,7 @@ pub struct LoadFactor(f32);
 
 impl LoadFactor {
     fn arb() -> impl Strategy<Value = Self> {
-        (1.0f32..=10.0f32).prop_map(Self)
+        (0.1f32..=10.0f32).prop_map(Self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,10 @@ impl<V> IntMap<V> {
         map
     }
 
-    /// Sets load rate of IntMap rounded to the first decimal point.
+    /// Sets the load factor of IntMap rounded to the first decimal point.
     ///
-    /// Values above 1.0 is allowed.
+    /// A load factor between 0.0 and 1.0 will reduce hash collisions but use more space.
+    /// A load factor above 1.0 will tolerate hash collisions and use less space.
     ///
     /// # Examples
     ///
@@ -80,7 +81,7 @@ impl<V> IntMap<V> {
         self.ensure_load_rate();
     }
 
-    /// Returns current load_factor
+    /// Returns the current load factor
     pub fn get_load_factor(&self) -> f32 {
         self.load_factor as f32 / 1000.
     }

--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -444,6 +444,19 @@ mod tests {
     fn load_factor() {
         let mut map: IntMap<u64> = IntMap::new();
 
+        map.set_load_factor(0.0);
+        assert_eq!(map.get_load_factor(), 0.0);
+
+        for i in 0..12 {
+            map.insert(i, i);
+        }
+
+        assert_eq!(map.capacity(), 16384);
+        assert!(map.load_rate() <= 1.);
+        assert!(map.collisions().is_empty());
+
+        let mut map: IntMap<u64> = IntMap::new();
+
         map.set_load_factor(0.1);
         assert_eq!(map.get_load_factor(), 0.1);
 


### PR DESCRIPTION
I was confused by the documentation of `IntMap::set_load_factor`. I thought that only values above 1.0 were allowed. I changed the documentation to my taste and made some small changes to the tests.