### PR TITLE
Support more integer types

### DIFF
--- a/integration_tests/random_ops/tests/random_ops.rs
+++ b/integration_tests/random_ops/tests/random_ops.rs
@@ -1,18 +1,40 @@
 use std::collections::HashMap;
 
-use intmap::IntMap;
+use intmap::{Int, IntMap};
 use intmap_integration_test_random_ops::{Ctor, Op};
 use proptest::prelude::*;
 
+// These tests performs random operations on IntMap to ensure that no operation
+// fails due to violated invariants. Also all mutable operations are performed
+// on an reference implementation (HashMap). The elements of the final IntMap
+// are compared with the elements of the reference implementation.
 proptest! {
-    // This test performs random operations on IntMap to ensure that no operation
-    // fails due to violated invariants. Also all mutable operations are performed
-    // on an reference implementation (HashMap). The elements of the final IntMap
-    // are compared with the elements of the reference implementation.
     #[test]
-    fn test_random_ops(
-        ctor in Ctor::arb(),
-        ops in Op::arb_vec(200),
+    fn test_random_ops_u32(
+        ctor in Ctor::<u32>::arb(),
+        ops in Op::<u32>::arb_vec(200),
+    ) {
+        let (mut map, mut reference) = ctor.apply();
+        assert_map(&map, &reference);
+
+        for op in ops {
+            op.apply(&mut map, &mut reference);
+            assert_map(&map, &reference);
+        }
+
+        let mut map_values = map.iter().collect::<Vec<_>>();
+        map_values.sort_by_key(|(&key, _)| key);
+
+        let mut reference_values = reference.iter().collect::<Vec<_>>();
+        reference_values.sort_by_key(|(&key, _)| key);
+
+        assert_eq!(map_values, reference_values);
+    }
+
+    #[test]
+    fn test_random_ops_u64(
+        ctor in Ctor::<u64>::arb(),
+        ops in Op::<u64>::arb_vec(200),
     ) {
         let (mut map, mut reference) = ctor.apply();
         assert_map(&map, &reference);
@@ -32,7 +54,7 @@ proptest! {
     }
 }
 
-fn assert_map(map: &IntMap<u8>, reference: &HashMap<u64, u8>) {
+fn assert_map<I: Int>(map: &IntMap<u8, I>, reference: &HashMap<I, u8>) {
     let debug = false;
     if debug {
         println!(

--- a/integration_tests/serde/tests/roundtrip.rs
+++ b/integration_tests/serde/tests/roundtrip.rs
@@ -4,8 +4,16 @@ use proptest::prelude::*;
 
 proptest! {
     #[test]
-    fn test_roundtrip(m in hash_map(any::<u64>(), any::<String>(), 0..20)) {
-        let im: IntMap<_> = m.into_iter().collect();
+    fn test_roundtrip_u32(m in hash_map(any::<u32>(), any::<String>(), 0..20)) {
+        let im: IntMap<_, u32> = m.into_iter().collect();
+        let bytes = serde_json::to_vec(&im).unwrap();
+        let im_copy = serde_json::from_slice(&bytes[..]).unwrap();
+        prop_assert_eq!(im, im_copy);
+    }
+
+    #[test]
+    fn test_roundtrip_u64(m in hash_map(any::<u64>(), any::<String>(), 0..20)) {
+        let im: IntMap<_, u64> = m.into_iter().collect();
         let bytes = serde_json::to_vec(&im).unwrap();
         let im_copy = serde_json::from_slice(&bytes[..]).unwrap();
         prop_assert_eq!(im, im_copy);

--- a/src/int.rs
+++ b/src/int.rs
@@ -1,0 +1,36 @@
+use std::fmt::Debug;
+
+pub trait SealedInt: Copy + PartialEq + Debug + SerdeInt {
+    fn calc_index(key: Self, mod_mask: usize) -> usize;
+}
+
+#[cfg(not(feature = "serde"))]
+pub trait SerdeInt {}
+
+#[cfg(feature = "serde")]
+pub trait SerdeInt: serde::Serialize + for<'de> serde::Deserialize<'de> {}
+
+macro_rules! impl_sealed_int {
+    ($int:ident, $prime:expr) => {
+        impl SealedInt for $int {
+            #[inline(always)]
+            fn calc_index(key: Self, mod_mask: usize) -> usize {
+                let hash = $prime.wrapping_mul(key);
+                // Faster modulus
+                (hash as usize) & mod_mask
+            }
+        }
+
+        impl SerdeInt for $int {}
+    };
+}
+
+impl_sealed_int! {
+    u32,
+    4294967291u32 // Largest prime for u32
+}
+
+impl_sealed_int! {
+    u64,
+    11400714819323198549u64 // Largest prime for u64
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -5,6 +5,7 @@ use std::slice::IterMut as SliceIterMut;
 use std::vec::Drain as VecDrain;
 use std::vec::IntoIter as VecIntoIter;
 
+use crate::Int;
 use crate::IntMap;
 
 // ***************** Iter *********************
@@ -113,9 +114,9 @@ impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
 
 // ***************** Into Iter *********************
 
-impl<V> IntoIterator for IntMap<V> {
-    type Item = (u64, V);
-    type IntoIter = IntoIter<u64, V>;
+impl<V, I: Int> IntoIterator for IntMap<V, I> {
+    type Item = (I, V);
+    type IntoIter = IntoIter<I, V>;
 
     fn into_iter(self) -> Self::IntoIter {
         IntoIter::new(self.cache)
@@ -179,9 +180,9 @@ impl<'a, K, V> Iterator for Drain<'a, K, V> {
 
 // ***************** Extend *********************
 
-impl<V> Extend<(u64, V)> for IntMap<V> {
+impl<V, I: Int> Extend<(I, V)> for IntMap<V, I> {
     #[inline]
-    fn extend<T: IntoIterator<Item = (u64, V)>>(&mut self, iter: T) {
+    fn extend<T: IntoIterator<Item = (I, V)>>(&mut self, iter: T) {
         for elem in iter {
             self.insert(elem.0, elem.1);
         }
@@ -190,13 +191,13 @@ impl<V> Extend<(u64, V)> for IntMap<V> {
 
 // ***************** FromIterator *********************
 
-impl<V> std::iter::FromIterator<(u64, V)> for IntMap<V> {
+impl<V, I: Int> std::iter::FromIterator<(I, V)> for IntMap<V, I> {
     #[inline]
-    fn from_iter<T: IntoIterator<Item = (u64, V)>>(iter: T) -> Self {
+    fn from_iter<T: IntoIterator<Item = (I, V)>>(iter: T) -> Self {
         let iterator = iter.into_iter();
         let (lower_bound, _) = iterator.size_hint();
 
-        let mut map = IntMap::with_capacity(lower_bound);
+        let mut map = IntMap::with_capacity_with(lower_bound);
         for elem in iterator {
             map.insert(elem.0, elem.1);
         }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,11 +1,11 @@
-use crate::IntMap;
+use crate::{Int, IntMap};
 use serde::{
     de::{Deserializer, MapAccess, Visitor},
     ser::SerializeMap,
     Deserialize, Serialize, Serializer,
 };
 
-impl<T: Serialize> Serialize for IntMap<T> {
+impl<T: Serialize, I: Int> Serialize for IntMap<T, I> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -18,7 +18,7 @@ impl<T: Serialize> Serialize for IntMap<T> {
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for IntMap<T> {
+impl<'de, T: Deserialize<'de>, I: Int> Deserialize<'de> for IntMap<T, I> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -27,11 +27,11 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for IntMap<T> {
     }
 }
 
-struct IntMapVisitor<V> {
-    marker: std::marker::PhantomData<fn() -> IntMap<V>>,
+struct IntMapVisitor<V, I = u64> {
+    marker: std::marker::PhantomData<fn() -> IntMap<V, I>>,
 }
 
-impl<V> IntMapVisitor<V> {
+impl<V, I: Int> IntMapVisitor<V, I> {
     fn new() -> Self {
         IntMapVisitor {
             marker: std::marker::PhantomData,
@@ -39,11 +39,11 @@ impl<V> IntMapVisitor<V> {
     }
 }
 
-impl<'de, V> Visitor<'de> for IntMapVisitor<V>
+impl<'de, V, I: Int> Visitor<'de> for IntMapVisitor<V, I>
 where
     V: Deserialize<'de>,
 {
-    type Value = IntMap<V>;
+    type Value = IntMap<V, I>;
 
     fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "IntMap<{}>", std::any::type_name::<V>())
@@ -53,7 +53,7 @@ where
     where
         M: MapAccess<'de>,
     {
-        let mut map = IntMap::with_capacity(access.size_hint().unwrap_or(0));
+        let mut map = IntMap::with_capacity_with(access.size_hint().unwrap_or(0));
 
         while let Some((key, value)) = access.next_entry()? {
             map.insert(key, value);


### PR DESCRIPTION
Add support for more integer types. Actually it was pretty easy.

I introduce a new sealed trait that is used by `IntMap`:

```rust
pub trait Int: int::SealedInt {}
```

~~The most complicated part was implementing the optional serde support. I found an ugly solution, but it's just an implementation detail that we could change later.~~

I need to change the type of `mod_mask` from `u64` to `usize`. But I'm think that's okay? We need to be careful here.

I think (but I'm not 100% sure) that this PR does not introduce any breaking changes. `IntMap` has now a default type parameter and new constructors:

```rust
pub struct IntMap<V, I = u64> { ... }

impl<V> for IntMap<V, u64> {
    pub const fn new() -> Self { ... }
    pub fn with_capacity(capacity: usize) -> Self { ... }
}

impl<V, I> for IntMap<V, I> {
    pub const fn new_with() -> Self { ... }
}

impl<V, I: Int> for IntMap<V, I> {
    // We should discuss the names...
    pub fn with_capacity_with(capacity: usize) -> Self { ... }
}
```

`Vec` from stdlib does something similar:

```rust
pub struct Vec<T, A: Allocator = Global> { ... }

impl<T> for Vec<T, Global> {
    pub const fn new() -> Self { ... }
    pub fn with_capacity(capacity: usize) -> Self { ... }
}

impl<T, A: Allocator> for Vec<T, A> {
    pub const fn new_in(alloc: A) -> Self { ... }
    pub fn with_capacity_in(capacity: usize, alloc: A) -> Self { ... }
}
```

However, if you prefer a breaking change we could remove the default, swap the type parameters and use the more common names `K` and `V`:

```rust
pub struct IntMap<K, V> { ... }

impl<K, V> for IntMap<K, V> {
    pub const fn new() -> Self { ... }
}

impl<K: Int, V> for IntMap<K, V> {
    pub fn with_capacity(capacity: usize) -> Self { ... }
}
```

Closes #61