### PR TITLE
Refactor CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ 1.58.1, 1.61.0 ]
+        rust:
+          - version: 1.58.1
+            run-all: false
+          - version: 1.80.1
+            run-all: true
 
     steps:
       - uses: actions/checkout@v2
@@ -18,31 +22,37 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ matrix.build }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.rust.version }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ matrix.build }}-cargo-
+            ${{ matrix.rust.version }}-cargo-
 
       - name: Install Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable -y
           source $HOME/.cargo/env
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
-          rustup component add rustfmt
+          rustup update ${{ matrix.rust.version }} --no-self-update
+          rustup default ${{ matrix.rust.version }}
 
-      - name: Check
+      - name: Check lib
+        run: $HOME/.cargo/bin/cargo check --lib
+
+      - name: Check all
         # We can't use --all-targets because it includes benches which requires nightly compiler
         run: $HOME/.cargo/bin/cargo check --workspace --lib --bins --examples --tests
+        if: ${{ matrix.rust.run-all }}
 
       - name: Clippy
         # We can't use --all-targets because it includes benches which requires nightly compiler
         run: $HOME/.cargo/bin/cargo clippy --workspace --lib --bins --examples --tests
+        if: ${{ matrix.rust.run-all }}
 
       - name: Check Format
         run: $HOME/.cargo/bin/cargo fmt --check
+        if: ${{ matrix.rust.run-all }}
 
       - name: Test
         run: $HOME/.cargo/bin/cargo test --workspace
+        if: ${{ matrix.rust.run-all }}
         env:
           RUST_BACKTRACE: 1
 


### PR DESCRIPTION
Okay... I neither understand GitHub Actions nor YAML... but I tried very hard!

The most important change is this:

```yaml
    strategy:
      matrix:
        rust:
          - version: 1.58.1
            run-all: false
          - version: 1.80.1
            run-all: true
```

Now we have a variable `run-all` that we can use as a condition for tasks like `cargo test`. Easy.

```yaml
      - name: Check lib
        run: $HOME/.cargo/bin/cargo check --lib

      - name: Check all
        # We can't use --all-targets because it includes benches which requires nightly compiler
        run: $HOME/.cargo/bin/cargo check --workspace --lib --bins --examples --tests
        if: ${{ matrix.rust.run-all }}
```

This works! I kept the older Rust version (1.58.1) because it tests the MSRV. But I increased the newer Rust version (1.61.0  -> 1.80.1) because it allows us to use shiny new stuff in tests and benchmarks.

Btw your cache didn't work. I think I fixed it. Previously you used the non-existing variable `matrix.build`. This resulted in this nice message:

```
Cache not found for input keys: -cargo-d04301ae37762a1e12b9e0e0deded45da81bd6e399ca943d66a6bb119bdd84c6, -cargo-
```

I was able to fix it by changing `matrix.build` to `matrix.rust.version`:

```
Cache restored successfully
Cache restored from key: 1.58.1-cargo-17a98d4477ebac4c9d1946e91ee5e564748d097ff95913d6e38944be8f2bdfb1
```

And one more think. I remove the line `rustup component add rustfmt` because it seems to be installed by default. This output was emitted before my change:

```
info: component 'rustfmt' for target 'x86_64-unknown-linux-gnu' is up to date
```