### PR TITLE
Add benchmarks for no-op, hashbrown and ahash

### DIFF
--- a/integration_tests/Cargo.lock
+++ b/integration_tests/Cargo.lock
@@ -3,6 +3,25 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "anstyle"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,13 +163,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -161,10 +190,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "intmap-benchmark"
+name = "intmap-integration-test-benchmark"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "divan",
+ "hashbrown 0.14.5",
  "indexmap",
  "intmap",
  "rand",
@@ -451,6 +482,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/integration_tests/benchmark/Cargo.toml
+++ b/integration_tests/benchmark/Cargo.toml
@@ -6,7 +6,9 @@ license = "MIT"
 publish = false
 
 [dev-dependencies]
+ahash = "0.8.11"
 divan = "0.1.14"
+hashbrown = "0.14.5"
 indexmap = "1.8.2"
 intmap = { path = "../.." }
 rand = "0.8.5"


### PR DESCRIPTION
Now that the benchmarks are separated from the main lib and the benchmarks run pretty fast with divan, I think we can move the benchmarks from the benchmark branch into master. I also made some minor changes to the benchmarks and benchmark names. Now the results look like this:

```
Timer precision: 10 ns
basic_bench                              fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ u64_get_ahash                         20.35 µs      │ 28.98 µs      │ 20.47 µs      │ 20.59 µs      │ 100     │ 100
├─ u64_get_brown                         21.95 µs      │ 22.73 µs      │ 22.06 µs      │ 22.06 µs      │ 100     │ 100
├─ u64_get_built_in                      93.85 µs      │ 180.7 µs      │ 94.44 µs      │ 95.67 µs      │ 100     │ 100
├─ u64_get_indexmap                      105 µs        │ 121.2 µs      │ 105.5 µs      │ 106.2 µs      │ 100     │ 100
├─ u64_get_intmap                        12 µs         │ 34.81 µs      │ 12.78 µs      │ 13.19 µs      │ 100     │ 100
├─ u64_get_no_op                         12.57 µs      │ 51.59 µs      │ 12.65 µs      │ 13.06 µs      │ 100     │ 100
├─ u64_insert_ahash                      60.06 µs      │ 83.71 µs      │ 76.81 µs      │ 75.73 µs      │ 100     │ 100
├─ u64_insert_brown                      40.75 µs      │ 44.53 µs      │ 41.34 µs      │ 41.47 µs      │ 100     │ 100
├─ u64_insert_built_in                   106.5 µs      │ 130 µs        │ 107.1 µs      │ 107.8 µs      │ 100     │ 100
├─ u64_insert_indexmap                   126.3 µs      │ 154.1 µs      │ 128.1 µs      │ 129.2 µs      │ 100     │ 100
├─ u64_insert_intmap                     28.39 µs      │ 146.9 µs      │ 29.64 µs      │ 31.32 µs      │ 100     │ 100
├─ u64_insert_intmap_checked             35.73 µs      │ 140.6 µs      │ 39.15 µs      │ 40.61 µs      │ 100     │ 100
├─ u64_insert_intmap_entry               50.26 µs      │ 153.6 µs      │ 56.81 µs      │ 57.79 µs      │ 100     │ 100
├─ u64_insert_no_op                      33.26 µs      │ 42.86 µs      │ 35.76 µs      │ 35.76 µs      │ 100     │ 100
├─ u64_insert_without_capacity_ahash     120.1 µs      │ 131.5 µs      │ 123 µs        │ 123.3 µs      │ 100     │ 100
├─ u64_insert_without_capacity_brown     112.3 µs      │ 123.6 µs      │ 113.5 µs      │ 114.2 µs      │ 100     │ 100
├─ u64_insert_without_capacity_built_in  260.8 µs      │ 277.9 µs      │ 263.7 µs      │ 264.3 µs      │ 100     │ 100
├─ u64_insert_without_capacity_intmap    473.7 µs      │ 604.6 µs      │ 482.6 µs      │ 499.9 µs      │ 100     │ 100
├─ u64_insert_without_capacity_no_op     98.54 µs      │ 118.4 µs      │ 100.6 µs      │ 101.3 µs      │ 100     │ 100
╰─ u64_resize_intmap                     29.3 µs       │ 33.65 µs      │ 29.45 µs      │ 29.58 µs      │ 100     │ 100
```

I added the author of #47 as co-author.