### PR TITLE
Allow other primitives as keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,6 +29,7 @@ dependencies = [
 name = "intmap"
 version = "2.0.0"
 dependencies = [
+ "num-traits",
  "rand",
  "serde",
 ]
@@ -32,6 +39,15 @@ name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/JesperAxelsson/rust-intmap"
 keywords = ["hashmap", "u64", "intmap"]
 
 [dependencies]
+num-traits = "0.2.18"
 serde = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![crates.io](https://img.shields.io/crates/v/intmap.svg)](https://crates.io/crates/intmap)
 
 # rust-intmap
-Specialized hashmap for `u64` keys
+Specialized hashmap for unsigned primitive keys
 
 Might be missing some functionality but you can remove, add, get and clear for now.
 
@@ -47,13 +47,13 @@ use intmap::IntMap;
 
 let mut map = IntMap::new();
 
-for i in 0..20_000 {
+for i in 0..20_000u32 {
     map.insert(i, format!("item: {:?}", i));
 }
 ```
 
 # How can it be so much faster?
-I use a specialized hash function for `u64` which multiplies the key with the largest prime for `u64`. By keeping the internal cache a power 2 you can avoid the expensive modulus operator as mentioned in [this Stack Overflow post](http://stackoverflow.com/questions/6670715/mod-of-power-2-on-bitwise-operators). The hash function looks like this:
+I use a specialized hash function, which multiplies the key with the largest prime for its type. By keeping the internal cache a power 2 you can avoid the expensive modulus operator as mentioned in [this Stack Overflow post](http://stackoverflow.com/questions/6670715/mod-of-power-2-on-bitwise-operators). The hash function looks like this:
 
 ```rust
 #[inline]

--- a/integration_tests/Cargo.lock
+++ b/integration_tests/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
 name = "intmap"
 version = "2.0.0"
 dependencies = [
+ "num-traits",
  "serde",
 ]
 

--- a/integration_tests/benchmark/benches/basic_bench.rs
+++ b/integration_tests/benchmark/benches/basic_bench.rs
@@ -322,7 +322,7 @@ fn u64_insert_without_capacity_intmap(bencher: Bencher) {
 #[bench]
 fn u64_resize_intmap(bencher: Bencher) {
     bencher.bench_local(|| {
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
         map.reserve(VEC_COUNT);
         black_box(&map);
     });

--- a/integration_tests/random_ops/src/lib.rs
+++ b/integration_tests/random_ops/src/lib.rs
@@ -79,7 +79,7 @@ impl Ctor {
         ]
     }
 
-    pub fn apply(&self) -> (IntMap<u8>, HashMap<u64, u8>) {
+    pub fn apply(&self) -> (IntMap<u64, u8>, HashMap<u64, u8>) {
         match self {
             Self::New => (IntMap::new(), HashMap::new()),
             Self::WithCapacity(capacity) => (IntMap::with_capacity(capacity.0), HashMap::new()),
@@ -160,7 +160,7 @@ impl Op {
         ]
     }
 
-    pub fn apply(&self, map: &mut IntMap<u8>, reference: &mut HashMap<u64, u8>) {
+    pub fn apply(&self, map: &mut IntMap<u64, u8>, reference: &mut HashMap<u64, u8>) {
         match self {
             Self::SetLoadFactor(load_factor) => {
                 map.set_load_factor(load_factor.0);

--- a/integration_tests/random_ops/tests/random_ops.rs
+++ b/integration_tests/random_ops/tests/random_ops.rs
@@ -32,7 +32,7 @@ proptest! {
     }
 }
 
-fn assert_map(map: &IntMap<u8>, reference: &HashMap<u64, u8>) {
+fn assert_map(map: &IntMap<u64, u8>, reference: &HashMap<u64, u8>) {
     let debug = false;
     if debug {
         println!(

--- a/integration_tests/serde/tests/roundtrip.rs
+++ b/integration_tests/serde/tests/roundtrip.rs
@@ -5,7 +5,7 @@ use proptest::prelude::*;
 proptest! {
     #[test]
     fn test_roundtrip(m in hash_map(any::<u64>(), any::<String>(), 0..20)) {
-        let im: IntMap<_> = m.into_iter().collect();
+        let im: IntMap<_, _> = m.into_iter().collect();
         let bytes = serde_json::to_vec(&im).unwrap();
         let im_copy = serde_json::from_slice(&bytes[..]).unwrap();
         prop_assert_eq!(im, im_copy);

--- a/src/highest_prime.rs
+++ b/src/highest_prime.rs
@@ -1,0 +1,31 @@
+pub trait HighestPrime {
+    fn highest_prime() -> Self;
+}
+
+impl HighestPrime for u64 {
+    #[inline(always)]
+    fn highest_prime() -> Self {
+        18_446_744_073_709_551_557
+    }
+}
+
+impl HighestPrime for u32 {
+    #[inline(always)]
+    fn highest_prime() -> Self {
+        2_147_483_647
+    }
+}
+
+impl HighestPrime for u16 {
+    #[inline(always)]
+    fn highest_prime() -> Self {
+        65_521
+    }
+}
+
+impl HighestPrime for u8 {
+    #[inline(always)]
+    fn highest_prime() -> Self {
+        251
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod highest_prime;
 mod iter;
 
 use core::iter::{IntoIterator, Iterator};
-use highest_prime::HighestPrime;
+pub use highest_prime::HighestPrime;
 use iter::*;
 use std::ops::{BitAnd, Sub};
 

--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -29,7 +29,7 @@ mod tests {
     fn intmap_get_insert_impl() {
         let count = 20_000;
         let data = get_random_range(count);
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         println!();
         println!("Starting test");
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn reserve() {
-        let mut map: IntMap<bool> = IntMap::new();
+        let mut map: IntMap<u64, bool> = IntMap::new();
         map.reserve(9001);
     }
 
@@ -80,7 +80,7 @@ mod tests {
     fn add_duplicate() {
         let mut map = IntMap::new();
 
-        for i in 0..20_000 {
+        for i in 0..20_000u64 {
             assert_eq!(map.insert(i, format!("item: {:?}", i)), None);
             assert_eq!(
                 map.insert(i, format!("item: {:?}", i)),
@@ -93,7 +93,7 @@ mod tests {
     fn add_duplicate_replace() {
         let mut map = IntMap::new();
 
-        for i in 0..20_000 {
+        for i in 0..20_000u64 {
             assert!(map.insert_checked(i, format!("item: {:?}", i)));
             assert!(!map.insert_checked(i, format!("item: {:?}", i)));
         }
@@ -103,7 +103,7 @@ mod tests {
     fn get_value_map() {
         let mut map = IntMap::new();
 
-        for i in 0..20_000 {
+        for i in 0..20_000u64 {
             assert!(map.insert_checked(i, i + 1));
         }
 
@@ -126,7 +126,7 @@ mod tests {
     fn get_value_not_in_map() {
         let mut map = IntMap::new();
 
-        for i in 0..20_000 {
+        for i in 0..20_000u64 {
             assert!(map.insert_checked(i, format!("item: {:?}", i)));
         }
 
@@ -140,7 +140,7 @@ mod tests {
     fn add_string() {
         let mut map = IntMap::new();
 
-        for i in 0..20_000 {
+        for i in 0..20_000u64 {
             map.insert(i, format!("item: {:?}", i));
         }
     }
@@ -149,7 +149,7 @@ mod tests {
     fn retain() {
         let mut map = IntMap::new();
 
-        for i in 0..20_000 {
+        for i in 0..20_000u64 {
             map.insert(i, format!("item: {:?}", i));
         }
 
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn single_add_get() {
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
         map.insert(21, 42);
         let val = map.get(21);
         assert!(val.is_some());
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn map_iter() {
         let count = 20_000;
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         for i in 0..count {
             map.insert(i, i);
@@ -187,7 +187,7 @@ mod tests {
     fn map_iter_keys() {
         let count = 20_000;
         let data: Vec<_> = (0..count).collect();
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         for i in 0..count {
             map.insert(i, i);
@@ -202,7 +202,7 @@ mod tests {
     fn map_iter_values() {
         let count = 20_000;
         let data: Vec<_> = (0..count).collect();
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         for i in 0..count {
             map.insert(i, i);
@@ -216,7 +216,7 @@ mod tests {
     #[test]
     fn map_iter_values_mut() {
         let count = 20_000;
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         for i in 0..count {
             map.insert(i, i);
@@ -234,7 +234,7 @@ mod tests {
     #[test]
     fn map_mut_iter() {
         let count = 20_000;
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         for i in 0..count {
             map.insert(i, i);
@@ -251,7 +251,7 @@ mod tests {
 
     #[test]
     fn map_iter_empty() {
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
         map.clear();
 
         if let Some(kv) = map.iter().next() {
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn map_mut_iter_empty() {
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
         map.clear();
 
         if let Some(kv) = map.iter_mut().next() {
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn map_into_iter() {
         let count = 20_000;
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         for i in 0..count {
             map.insert(i, i);
@@ -286,7 +286,7 @@ mod tests {
     #[test]
     fn map_drain() {
         let count = 20_000;
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         for i in 0..count {
             map.insert(i, i);
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn map_into_iter_empty() {
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
         map.clear();
 
         if let Some(kv) = map.into_iter().next() {
@@ -311,8 +311,8 @@ mod tests {
     #[test]
     fn extend_two_maps() {
         let count = 20_000;
-        let mut map_1: IntMap<u64> = IntMap::new();
-        let mut map_2: IntMap<u64> = IntMap::new();
+        let mut map_1: IntMap<u64, u64> = IntMap::new();
+        let mut map_2: IntMap<u64, u64> = IntMap::new();
 
         for i in 0..count {
             map_1.insert(i, i);
@@ -335,7 +335,7 @@ mod tests {
     fn from_iter_collect() {
         let count = 20_000;
 
-        let map = (0..count).map(|i| (i, i * i)).collect::<IntMap<_>>();
+        let map = (0..count).map(|i| (i, i * i)).collect::<IntMap<u64, _>>();
 
         for k in 0..count {
             assert!(map.contains_key(k));
@@ -350,17 +350,20 @@ mod tests {
     fn map_equality() {
         let count = 5_000;
 
-        let map_1 = (0..count).map(|i| (i, i * i)).collect::<IntMap<_>>();
+        let map_1 = (0..count).map(|i| (i, i * i)).collect::<IntMap<u64, _>>();
 
-        let map_2 = (0..count).rev().map(|i| (i, i * i)).collect::<IntMap<_>>();
+        let map_2 = (0..count)
+            .rev()
+            .map(|i| (i, i * i))
+            .collect::<IntMap<u64, _>>();
 
         assert_eq!(map_1, map_2);
     }
 
     #[test]
     fn map_inequality() {
-        let map_1 = (0..10).map(|i| (i, i * i)).collect::<IntMap<_>>();
-        let map_2 = (0..5).rev().map(|i| (i, i * i)).collect::<IntMap<_>>();
+        let map_1 = (0..10).map(|i| (i, i * i)).collect::<IntMap<u64, _>>();
+        let map_2 = (0..5).rev().map(|i| (i, i * i)).collect::<IntMap<u64, _>>();
 
         assert_ne!(map_1, map_2);
         assert_ne!(map_2, map_1);
@@ -370,7 +373,7 @@ mod tests {
     fn entry_api() {
         let count = 20_000;
         let data: Vec<u64> = (0..count).collect();
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         // Insert values 0..19999
         for i in 0..count {
@@ -421,7 +424,7 @@ mod tests {
     #[test]
     fn test_debug_features() {
         let count = 20_000;
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         for i in 0..count {
             map.insert(i, i);
@@ -432,7 +435,7 @@ mod tests {
         assert!(map.load_rate() > 0.70);
         assert!(map.collisions().is_empty());
 
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
         for i in 0..3 {
             map.insert(i, i + 1);
         }
@@ -442,7 +445,7 @@ mod tests {
 
     #[test]
     fn load_factor() {
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         map.set_load_factor(0.0);
         assert_eq!(map.get_load_factor(), 0.0);
@@ -455,7 +458,7 @@ mod tests {
         assert!(map.load_rate() <= 1.);
         assert!(map.collisions().is_empty());
 
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         map.set_load_factor(0.1);
         assert_eq!(map.get_load_factor(), 0.1);
@@ -468,7 +471,7 @@ mod tests {
         assert!(map.load_rate() <= 10.);
         assert!(map.collisions().is_empty());
 
-        let mut map: IntMap<u64> = IntMap::new();
+        let mut map: IntMap<u64, u64> = IntMap::new();
 
         map.set_load_factor(2.);
         assert_eq!(map.get_load_factor(), 2.);


### PR DESCRIPTION
This change makes it possible to use other primitives as keys.
There are a lot of function-level constraints, which could be either
aliased, or lifted to the impl clause, but I prefer to have the
minimal set on a per-function basis.

This is a breaking change, because of the introduction of the extra type
parameter.