### PR TITLE
Use K instead of &K in API

### DIFF
--- a/integration_tests/random_ops/tests/random_ops.rs
+++ b/integration_tests/random_ops/tests/random_ops.rs
@@ -82,7 +82,7 @@ fn test_random_ops<K: TestIntKey + Ord>(ctor: Ctor<K>, ops: Vec<Op<K>>) {
     let mut map_values = map.iter().collect::<Vec<_>>();
     map_values.sort_by_key(|(key, _)| *key);
 
-    let mut reference_values = reference.iter().collect::<Vec<_>>();
+    let mut reference_values = reference.iter().map(|(&k, v)| (k, v)).collect::<Vec<_>>();
     reference_values.sort_by_key(|(key, _)| *key);
 
     assert_eq!(map_values, reference_values);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -23,11 +23,11 @@ impl<'a, K: IntKey, V> Iter<'a, K, V> {
 }
 
 impl<'a, K: IntKey, V> Iterator for Iter<'a, K, V> {
-    type Item = (&'a K, &'a V);
+    type Item = (K, &'a V);
 
     #[inline]
-    fn next(&mut self) -> Option<(&'a K, &'a V)> {
-        self.inner.next().map(|r| (&r.0, &r.1))
+    fn next(&mut self) -> Option<(K, &'a V)> {
+        self.inner.next().map(|r| (r.0, &r.1))
     }
 }
 
@@ -46,11 +46,11 @@ impl<'a, K: IntKey, V> IterMut<'a, K, V> {
 }
 
 impl<'a, K: IntKey, V> Iterator for IterMut<'a, K, V> {
-    type Item = (&'a K, &'a mut V);
+    type Item = (K, &'a mut V);
 
     #[inline]
-    fn next(&mut self) -> Option<(&'a K, &'a mut V)> {
-        self.inner.next().map(|r| (&r.0, &mut r.1))
+    fn next(&mut self) -> Option<(K, &'a mut V)> {
+        self.inner.next().map(|r| (r.0, &mut r.1))
     }
 }
 
@@ -61,10 +61,10 @@ pub struct Keys<'a, K: IntKey, V> {
 }
 
 impl<'a, K: IntKey, V> Iterator for Keys<'a, K, V> {
-    type Item = &'a K;
+    type Item = K;
 
     #[inline]
-    fn next(&mut self) -> Option<&'a K> {
+    fn next(&mut self) -> Option<K> {
         self.inner.next().map(|kv| kv.0)
     }
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,8 +588,8 @@ where
     V: PartialEq,
 {
     fn eq(&self, other: &IntMap<K, V>) -> bool {
-        self.iter().all(|(&k, a)| other.get(k) == Some(a))
-            && other.iter().all(|(&k, a)| self.get(k) == Some(a))
+        self.iter().all(|(k, a)| other.get(k) == Some(a))
+            && other.iter().all(|(k, a)| self.get(k) == Some(a))
     }
 }
 impl<K: IntKey, V: Eq> Eq for IntMap<K, V> {}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -16,7 +16,7 @@ where
     {
         let mut map = serializer.serialize_map(Some(self.len()))?;
         for (k, v) in self.iter() {
-            map.serialize_entry(k, v)?;
+            map.serialize_entry(&k, v)?;
         }
         map.end()
     }

--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -179,7 +179,7 @@ mod tests {
         }
 
         for (k, v) in map.iter() {
-            assert_eq!(*k, *v);
+            assert_eq!(k, *v);
         }
     }
 
@@ -194,7 +194,7 @@ mod tests {
         }
 
         for k in map.keys() {
-            assert_eq!(*k, data[*k as usize]);
+            assert_eq!(k, data[k as usize]);
         }
     }
 
@@ -326,7 +326,7 @@ mod tests {
 
         assert_eq!(map_1.len(), (count * 2) as usize);
 
-        for (k, v) in map_1.iter() {
+        for (k, &v) in map_1.iter() {
             assert_eq!(k, v);
         }
     }
@@ -341,7 +341,7 @@ mod tests {
             assert!(map.contains_key(k));
         }
 
-        for (&k, &v) in map.iter() {
+        for (k, &v) in map.iter() {
             assert_eq!(k * k, v);
         }
     }
@@ -385,8 +385,8 @@ mod tests {
 
         assert_eq!(map.len(), count as usize);
 
-        for (k, v) in map.iter() {
-            assert_eq!(*v, data[*k as usize]);
+        for (k, &v) in map.iter() {
+            assert_eq!(v, data[k as usize]);
         }
 
         // Replace values 0..19999 with 20000..39999
@@ -404,8 +404,8 @@ mod tests {
 
         assert_eq!(map.len(), count as usize);
 
-        for (k, v) in map.iter() {
-            assert_eq!(*v, count + data[*k as usize]);
+        for (k, &v) in map.iter() {
+            assert_eq!(v, count + data[k as usize]);
         }
 
         // Remove values 20000..39999


### PR DESCRIPTION
IMO there is no reason to use `&K` in the public API because `K` implements `Copy`. This PR should change all occurrences of `&K` to `K`.

Closes #70 