### PR TITLE
Fix link to changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ test tests::u64_resize_intmap                    ... bench:      55,155.88 ns/it
 ```
 # Breaking Changes
 
-Breaking changes are documented in the [CHANGELOG.md].
+Breaking changes are documented in the [changelog](CHANGELOG.md).
 
 # How to use
 Simple example:


### PR DESCRIPTION
I confused markdown with rustdoc and its convenient link syntax. The link should work now. Proof:

![image](https://github.com/user-attachments/assets/0bb665ba-6241-49da-815b-c12ec53e3927)

