### PR TITLE
Avoid re-hashing (twice!) in VacantEntry::insert

### DIFF
--- a/integration_tests/Cargo.lock
+++ b/integration_tests/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "intmap"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
Anecdotal local benchmarks:

```
# Before
├─ u64_insert_intmap_entry               67.45 µs      │ 164.8 µs      │ 67.79 µs      │ 69.32 µs      │ 100     │ 100
# After
├─ u64_insert_intmap_entry               44.83 µs      │ 155.7 µs      │ 45.22 µs      │ 47.24 µs      │ 100     │ 100
```
