### PR TITLE
Allow to use for on references to IntMap

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -10,6 +10,15 @@ use crate::IntMap;
 
 // ***************** Iter *********************
 
+impl<'a, K: IntKey, V> IntoIterator for &'a IntMap<K, V> {
+    type Item = (K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Iter::new(&self.cache)
+    }
+}
+
 /// An iterator over the entries of a [`IntMap`]
 ///
 /// This struct is created by [`IntMap::iter`].
@@ -35,6 +44,15 @@ impl<'a, K: IntKey, V> Iterator for Iter<'a, K, V> {
 }
 
 // ***************** Iter Mut *********************
+
+impl<'a, K: IntKey, V> IntoIterator for &'a mut IntMap<K, V> {
+    type Item = (K, &'a mut V);
+    type IntoIter = IterMut<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IterMut::new(&mut self.cache)
+    }
+}
 
 /// A mutable iterator over the entries of a [`IntMap`].
 ///

--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -284,6 +284,28 @@ mod tests {
     }
 
     #[test]
+    fn map_for() {
+        let count = 20_000;
+        let mut map: IntMap<u64, u64> = IntMap::new();
+
+        for i in 0..count {
+            map.insert(i, i);
+        }
+
+        for (k, v) in &map {
+            assert_eq!(k, *v);
+        }
+
+        for (k, v) in &mut map {
+            assert_eq!(k, *v);
+        }
+
+        for (k, v) in map {
+            assert_eq!(k, v);
+        }
+    }
+
+    #[test]
     fn map_drain() {
         let count = 20_000;
         let mut map: IntMap<u64, u64> = IntMap::new();


### PR DESCRIPTION
Hello,

Currently, doing a for loop on a reference to `IntMap` does not work. As an example, the following code does not compile.
```rust
let mut map: IntMap<u64, u64> = IntMap::new();

for (k, v) in &map {
    // ...
}

for (k, v) in &mut map {
    // ...
}
```

This PR implements `IntoIterator` on `&IntMap` and `&mut IntMap` to solve this issue.